### PR TITLE
Renames package back from main to go_avrocodec_wrapper

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -1,4 +1,4 @@
-package main
+package go_avrocodec_wrapper
 
 import (
 	"encoding/binary"

--- a/test.go
+++ b/test.go
@@ -1,4 +1,4 @@
-package main
+package go_avrocodec_wrapper
 
 import (
 	"encoding/json"

--- a/test_test.go
+++ b/test_test.go
@@ -1,4 +1,4 @@
-package main
+package go_avrocodec_wrapper
 
 import (
 	"encoding/json"


### PR DESCRIPTION
Every package named "main" in go language is recognized as an executable. For this reason since the last change that renames package to "main" the library can't be used.

This change fixes that.